### PR TITLE
feat: CAPTAIN ecosystem integration

### DIFF
--- a/.claude/hookify.agent-output-quality.local.md
+++ b/.claude/hookify.agent-output-quality.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.agent-output-quality.local.md

--- a/.claude/hookify.agent-routing-validation.local.md
+++ b/.claude/hookify.agent-routing-validation.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.agent-routing-validation.local.md

--- a/.claude/hookify.assumption-surfacing.local.md
+++ b/.claude/hookify.assumption-surfacing.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.assumption-surfacing.local.md

--- a/.claude/hookify.autonomy-enforcement.local.md
+++ b/.claude/hookify.autonomy-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.autonomy-enforcement.local.md

--- a/.claude/hookify.blast-radius-audit.local.md
+++ b/.claude/hookify.blast-radius-audit.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.blast-radius-audit.local.md

--- a/.claude/hookify.canva-folder-enforcement.local.md
+++ b/.claude/hookify.canva-folder-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.canva-folder-enforcement.local.md

--- a/.claude/hookify.content-integration.local.md
+++ b/.claude/hookify.content-integration.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.content-integration.local.md

--- a/.claude/hookify.cross-reference-check.local.md
+++ b/.claude/hookify.cross-reference-check.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.cross-reference-check.local.md

--- a/.claude/hookify.decision-fatigue.local.md
+++ b/.claude/hookify.decision-fatigue.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.decision-fatigue.local.md

--- a/.claude/hookify.decision-gate.local.md
+++ b/.claude/hookify.decision-gate.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.decision-gate.local.md

--- a/.claude/hookify.deep-tier-output-enforcement.local.md
+++ b/.claude/hookify.deep-tier-output-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.deep-tier-output-enforcement.local.md

--- a/.claude/hookify.deliverable-quality-gate.local.md
+++ b/.claude/hookify.deliverable-quality-gate.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.deliverable-quality-gate.local.md

--- a/.claude/hookify.drift-detection.local.md
+++ b/.claude/hookify.drift-detection.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.drift-detection.local.md

--- a/.claude/hookify.format-compliance.local.md
+++ b/.claude/hookify.format-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.format-compliance.local.md

--- a/.claude/hookify.label-compliance.local.md
+++ b/.claude/hookify.label-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.label-compliance.local.md

--- a/.claude/hookify.linear-first-planning.local.md
+++ b/.claude/hookify.linear-first-planning.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.linear-first-planning.local.md

--- a/.claude/hookify.max-in-progress.local.md
+++ b/.claude/hookify.max-in-progress.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.max-in-progress.local.md

--- a/.claude/hookify.memory-update.local.md
+++ b/.claude/hookify.memory-update.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.memory-update.local.md

--- a/.claude/hookify.project-assignment.local.md
+++ b/.claude/hookify.project-assignment.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.project-assignment.local.md

--- a/.claude/hookify.proxy-image-enforcement.local.md
+++ b/.claude/hookify.proxy-image-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.proxy-image-enforcement.local.md

--- a/.claude/hookify.readme-compliance.local.md
+++ b/.claude/hookify.readme-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.readme-compliance.local.md

--- a/.claude/hookify.repo-label-compliance.local.md
+++ b/.claude/hookify.repo-label-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.repo-label-compliance.local.md

--- a/.claude/hookify.stale-streaks.local.md
+++ b/.claude/hookify.stale-streaks.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.stale-streaks.local.md

--- a/.claude/hookify.token-leak-prevention.local.md
+++ b/.claude/hookify.token-leak-prevention.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.token-leak-prevention.local.md

--- a/.claude/hookify.tool-inventory-reminder.local.md
+++ b/.claude/hookify.tool-inventory-reminder.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.tool-inventory-reminder.local.md

--- a/.claude/rules/hookify/hookify.agent-output-quality.local.md
+++ b/.claude/rules/hookify/hookify.agent-output-quality.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.agent-output-quality.local.md

--- a/.claude/rules/hookify/hookify.agent-routing-validation.local.md
+++ b/.claude/rules/hookify/hookify.agent-routing-validation.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.agent-routing-validation.local.md

--- a/.claude/rules/hookify/hookify.assumption-surfacing.local.md
+++ b/.claude/rules/hookify/hookify.assumption-surfacing.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.assumption-surfacing.local.md

--- a/.claude/rules/hookify/hookify.autonomy-enforcement.local.md
+++ b/.claude/rules/hookify/hookify.autonomy-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.autonomy-enforcement.local.md

--- a/.claude/rules/hookify/hookify.blast-radius-audit.local.md
+++ b/.claude/rules/hookify/hookify.blast-radius-audit.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.blast-radius-audit.local.md

--- a/.claude/rules/hookify/hookify.canva-folder-enforcement.local.md
+++ b/.claude/rules/hookify/hookify.canva-folder-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.canva-folder-enforcement.local.md

--- a/.claude/rules/hookify/hookify.content-integration.local.md
+++ b/.claude/rules/hookify/hookify.content-integration.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.content-integration.local.md

--- a/.claude/rules/hookify/hookify.cross-reference-check.local.md
+++ b/.claude/rules/hookify/hookify.cross-reference-check.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.cross-reference-check.local.md

--- a/.claude/rules/hookify/hookify.decision-fatigue.local.md
+++ b/.claude/rules/hookify/hookify.decision-fatigue.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.decision-fatigue.local.md

--- a/.claude/rules/hookify/hookify.decision-gate.local.md
+++ b/.claude/rules/hookify/hookify.decision-gate.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.decision-gate.local.md

--- a/.claude/rules/hookify/hookify.deep-tier-output-enforcement.local.md
+++ b/.claude/rules/hookify/hookify.deep-tier-output-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.deep-tier-output-enforcement.local.md

--- a/.claude/rules/hookify/hookify.deliverable-quality-gate.local.md
+++ b/.claude/rules/hookify/hookify.deliverable-quality-gate.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.deliverable-quality-gate.local.md

--- a/.claude/rules/hookify/hookify.drift-detection.local.md
+++ b/.claude/rules/hookify/hookify.drift-detection.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.drift-detection.local.md

--- a/.claude/rules/hookify/hookify.format-compliance.local.md
+++ b/.claude/rules/hookify/hookify.format-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.format-compliance.local.md

--- a/.claude/rules/hookify/hookify.label-compliance.local.md
+++ b/.claude/rules/hookify/hookify.label-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.label-compliance.local.md

--- a/.claude/rules/hookify/hookify.linear-first-planning.local.md
+++ b/.claude/rules/hookify/hookify.linear-first-planning.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.linear-first-planning.local.md

--- a/.claude/rules/hookify/hookify.max-in-progress.local.md
+++ b/.claude/rules/hookify/hookify.max-in-progress.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.max-in-progress.local.md

--- a/.claude/rules/hookify/hookify.memory-update.local.md
+++ b/.claude/rules/hookify/hookify.memory-update.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.memory-update.local.md

--- a/.claude/rules/hookify/hookify.project-assignment.local.md
+++ b/.claude/rules/hookify/hookify.project-assignment.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.project-assignment.local.md

--- a/.claude/rules/hookify/hookify.proxy-image-enforcement.local.md
+++ b/.claude/rules/hookify/hookify.proxy-image-enforcement.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.proxy-image-enforcement.local.md

--- a/.claude/rules/hookify/hookify.readme-compliance.local.md
+++ b/.claude/rules/hookify/hookify.readme-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.readme-compliance.local.md

--- a/.claude/rules/hookify/hookify.repo-label-compliance.local.md
+++ b/.claude/rules/hookify/hookify.repo-label-compliance.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.repo-label-compliance.local.md

--- a/.claude/rules/hookify/hookify.stale-streaks.local.md
+++ b/.claude/rules/hookify/hookify.stale-streaks.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.stale-streaks.local.md

--- a/.claude/rules/hookify/hookify.token-leak-prevention.local.md
+++ b/.claude/rules/hookify/hookify.token-leak-prevention.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.token-leak-prevention.local.md

--- a/.claude/rules/hookify/hookify.tool-inventory-reminder.local.md
+++ b/.claude/rules/hookify/hookify.tool-inventory-reminder.local.md
@@ -1,0 +1,1 @@
+/Users/dillon.w/Projects/Dillons Project/.claude/rules/hookify/hookify.tool-inventory-reminder.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,20 @@
 @AGENTS.md
+
+## CAPTAIN Ecosystem Context
+
+> Forked from [JCodesMore/ai-website-cloner-template](https://github.com/JCodesMore/ai-website-cloner-template). Customized for CAPTAIN.
+
+- **Team:** The Forge (business tooling)
+- **Project:** The War Room — business operations, client site analysis
+- **Config key:** `cloner` in `~/.claude/captain.config.json`
+- **Category:** tool (forked third-party)
+
+## Cross-Repo Rules
+
+- **Reference but not update.** When working in this repo, you can READ from other CAPTAIN repos via captain.config.json. Never WRITE to another repo from a session focused here.
+- **Branch strategy:** `main` stays synced with upstream via rebase. All CAPTAIN customizations go on the `captain` branch.
+
+## Upstream Tracking
+
+- **Upstream:** https://github.com/JCodesMore/ai-website-cloner-template.git
+- **Sync:** `git fetch upstream && git checkout main && git rebase upstream/main && git checkout captain && git rebase main`


### PR DESCRIPTION
## Summary
- Layer CAPTAIN ecosystem context onto existing CLAUDE.md (preserves @AGENTS.md reference and /clone-website skill)
- Add 25 hookify enforcement rules via bootstrap distribution (symlinks)
- Establish Forge team / War Room project assignment
- Document cross-repo rules and upstream sync strategy

## Changes
- `CLAUDE.md` — appended CAPTAIN context, cross-repo rules, upstream tracking
- `.claude/hookify.*.local.md` — 25 symlinked enforcement rules (root)
- `.claude/rules/hookify/` — 25 symlinked enforcement rules (standard path)

## Test plan
- [ ] `@AGENTS.md` reference still on line 1 of CLAUDE.md
- [ ] `/clone-website` skill at `.claude/skills/clone-website/SKILL.md` unchanged
- [ ] CAPTAIN context sections present in CLAUDE.md
- [ ] Hookify rules are valid symlinks
- [ ] No upstream source files modified

Refs: BRG-166, BRG-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)