### PR TITLE
fix: resolve gemini CLI validation errors by adding name field and fl…

### DIFF
--- a/.gemini/commands/clone-website.toml
+++ b/.gemini/commands/clone-website.toml
@@ -2,9 +2,9 @@
 # Run `node scripts/sync-skills.mjs` to regenerate.
 
 description = "Reverse-engineer and clone any website as a pixel-perfect replica"
+name = "clone-website"
 
-[prompt]
-text = '''
+prompt = '''
 
 # Clone Website
 

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -71,8 +71,9 @@ write(
   '.gemini/commands/clone-website.toml',
   `# AUTO-GENERATED from .claude/skills/clone-website/SKILL.md\n` +
     `# Run \`node scripts/sync-skills.mjs\` to regenerate.\n\n` +
-    `description = "${shortDesc}"\n\n` +
-    `[prompt]\ntext = '''\n${geminiBody}\n'''\n`
+    `description = "${shortDesc}"\n` +
+    `name = "clone-website"\n\n` +
+    `prompt = '''\n${geminiBody}\n'''\n`
 );
 
 // 6. OpenCode — markdown + YAML frontmatter, $ARGUMENTS works natively


### PR DESCRIPTION
…attening prompt key

## Summary
*"Fixed the TOML schema in the gemini command generator to correctly use a flat `prompt = ` key and include the required `name` field, resolving `FileCommandLoader` validation errors."*
<!-- What does this PR do and why? -->

## Related Issue

<!-- Link to the issue this addresses, e.g. Closes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Breaking change

## Checklist

- [ ] `npm run check` passes (lint + typecheck + build)
