### PR TITLE
ci: verify generated agent/skill files stay in sync with their sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,34 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  sync:
+    name: Generated files in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Regenerate agent rules and platform skills
+        run: |
+          bash scripts/sync-agent-rules.sh
+          node scripts/sync-skills.mjs
+
+      - name: Verify generated files are committed
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Generated files are out of sync with their sources (AGENTS.md / SKILL.md)."
+            echo "Run the sync scripts locally and commit the result:"
+            echo "  bash scripts/sync-agent-rules.sh"
+            echo "  node scripts/sync-skills.mjs"
+            git diff --stat
+            exit 1
+          fi
+          echo "All generated files are in sync with their sources."


### PR DESCRIPTION
AGENTS.md asks contributors to re-run the sync scripts after editing a source file, but nothing actually enforces it. It's easy to edit AGENTS.md or the clone-website SKILL.md and forget to regenerate, which quietly drifts the 13 generated platform files (Cursor, Windsurf, Gemini, Codex, Copilot, Amazon Q, Continue, Cline, OpenCode, Augment) from their source. Right now CI only runs lint/typecheck/build, so that slips through.

This adds a small `sync` job that re-runs both sync scripts and fails if the working tree comes back dirty, with a message pointing at the fix:

```
::error::Generated files are out of sync with their sources (AGENTS.md / SKILL.md).
Run the sync scripts locally and commit the result:
  bash scripts/sync-agent-rules.sh
  node scripts/sync-skills.mjs
```

It runs as a separate job so it doesn't slow the existing one down, and it's a no-op when things are already in sync (the scripts are deterministic — checked there's no diff on a clean master).