### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thanks for your interest in improving the **AI Website Cloner Template**! This guide covers how to contribute to the template itself.
+
+> **Note:** This repository is a *template*. If you just want to clone a website, don't open a PR here — click **Use this template** to make your own copy and work there (see the [README](README.md#quick-start)). Pull requests should improve the template: the `/clone-website` skill, agent platform support, the scaffold, or the docs.
+
+## Ways to contribute
+
+- **Improve the `/clone-website` skill** — sharper extraction, better prompts, new behaviors to detect
+- **Add or fix agent platform support** — new coding agents, or fixes to existing generated configs
+- **Fix bugs** in the Next.js scaffold or the sync scripts
+- **Improve documentation** — the README, `AGENTS.md`, or the inspection guides under `docs/research/`
+
+Browse the [open issues](https://github.com/JCodesMore/ai-website-cloner-template/issues) for something to pick up. For larger changes, open an issue first so we can align on the approach before you build.
+
+## Development setup
+
+**Prerequisites:** [Node.js](https://nodejs.org/) 24+.
+
+```bash
+git clone https://github.com/YOUR-USERNAME/ai-website-cloner-template.git
+cd ai-website-cloner-template
+npm install
+```
+
+Before opening a PR, make sure the project is green:
+
+```bash
+npm run check   # lint + typecheck + build
+```
+
+## Source-of-truth files & the sync scripts
+
+This is the most important thing to know. Two files power *all* platform support, and their platform-specific copies are **generated** — never edit a generated file directly.
+
+| What                   | Edit this (source of truth)             | Then run                           |
+| ---------------------- | --------------------------------------- | ---------------------------------- |
+| Project instructions   | `AGENTS.md`                             | `bash scripts/sync-agent-rules.sh` |
+| `/clone-website` skill | `.claude/skills/clone-website/SKILL.md` | `node scripts/sync-skills.mjs`     |
+
+After editing a source file, run the matching sync command and commit the regenerated files along with your change. CI verifies that the generated files are in sync — if you forget to regenerate, the build will fail with a reminder.
+
+## Submitting a pull request
+
+1. **Fork** the repo and create a branch off `master` (e.g. `fix/skill-hover-extraction` or `docs/clarify-setup`).
+2. Make your change. If you touched a source-of-truth file, **run the relevant sync script** (see above).
+3. Run `npm run check` and make sure it passes.
+4. Write a clear commit message. This repo uses [Conventional Commits](https://www.conventionalcommits.org/) — e.g. `fix:`, `feat:`, `docs:`, `chore:`, `ci:`.
+5. Open a PR against `master`, fill out the PR template, and link the issue it addresses (`Closes #123`).
+6. Keep PRs focused — one logical change per PR is much easier to review and merge.
+
+## Questions
+
+Ask in the [Discord community](https://discord.gg/hrTSX5yTpB) — happy to help you get started.


### PR DESCRIPTION
There's no contributor guide in the repo yet, even though it gets a fair number of outside PRs. A couple of repo-specific things are easy to miss without one:

- This is a template — people sometimes open PRs here with their generated website instead of using "Use this template" to make their own copy.
- AGENTS.md and the clone-website SKILL.md are the source of truth; their per-platform copies are generated and have to be regenerated with the sync scripts.

This adds a short CONTRIBUTING.md covering ways to help, dev setup (Node 24+, `npm run check`), the sync workflow, and the basic PR conventions. It doesn't introduce any new policy — it just writes down what's already in the README and AGENTS.md.