### PR TITLE
ci: verify generated files stay in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,34 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  sync:
+    name: Generated files in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Regenerate agent rules and platform skills
+        run: |
+          bash scripts/sync-agent-rules.sh
+          node scripts/sync-skills.mjs
+
+      - name: Verify generated files are committed
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Generated files are out of sync with their sources (AGENTS.md / SKILL.md)."
+            echo "Run the sync scripts locally and commit the result:"
+            echo "  bash scripts/sync-agent-rules.sh"
+            echo "  node scripts/sync-skills.mjs"
+            git diff --stat
+            exit 1
+          fi
+          echo "All generated files are in sync with their sources."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,30 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
+
+      - name: Verify generated files are in sync
+        shell: bash
+        run: |
+          bash scripts/sync-agent-rules.sh
+          node scripts/sync-skills.mjs
+
+          if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+            echo "::error::Generated files are out of sync with their sources (AGENTS.md / SKILL.md)."
+            echo "Run the sync scripts locally and commit the result:"
+            echo "  bash scripts/sync-agent-rules.sh"
+            echo "  node scripts/sync-skills.mjs"
+            git status --short
+            git diff --stat
+            exit 1
+          fi
+          echo "All generated files are in sync with their sources."
 
       - name: Install dependencies
         run: npm ci
@@ -34,34 +51,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-  sync:
-    name: Generated files in sync
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: Regenerate agent rules and platform skills
-        run: |
-          bash scripts/sync-agent-rules.sh
-          node scripts/sync-skills.mjs
-
-      - name: Verify generated files are committed
-        run: |
-          if ! git diff --quiet; then
-            echo "::error::Generated files are out of sync with their sources (AGENTS.md / SKILL.md)."
-            echo "Run the sync scripts locally and commit the result:"
-            echo "  bash scripts/sync-agent-rules.sh"
-            echo "  node scripts/sync-skills.mjs"
-            git diff --stat
-            exit 1
-          fi
-          echo "All generated files are in sync with their sources."


### PR DESCRIPTION
## What changed

- Preserves YAMRAJ13y's original generated-file synchronization check from #57.
- Runs both synchronization generators early in the existing quality job instead of starting a second runner.
- Checks `git status --porcelain=v1 --untracked-files=all`, so CI catches modified, deleted, and newly generated untracked files.
- Updates `actions/checkout` and `actions/setup-node` to their current Node 24-based v7 releases.

## Why

The repository commits platform-specific copies generated from `AGENTS.md` and `.claude/skills/clone-website/SKILL.md`. CI should fail when those copies are stale. The original #57 implementation used `git diff --quiet`, which does not report untracked files and could therefore miss a newly introduced generated output.

## Validation

- Clean checkout remained clean after both generators.
- Changing `AGENTS.md` without committing regenerated files was detected.
- A new untracked platform output was detected while the original `git diff --quiet` check returned success.
- `npm run check` passed: lint, TypeScript, and the Next.js production build.
- Independent workflow review found no actionable issues.

Supersedes #57 while preserving the contributor-authored commit and credit.
