### PR TITLE
docs: add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for your interest in improving the **AI Website Cloner Template**! This g
 - **Fix bugs** in the Next.js scaffold or the sync scripts
 - **Improve documentation** — the README, `AGENTS.md`, or the inspection guides under `docs/research/`
 
-Browse the [open issues](https://github.com/JCodesMore/ai-website-cloner-template/issues) for something to pick up. For larger changes, open an issue first so we can align on the approach before you build.
+Browse the [open issues](https://github.com/JCodesMore/ai-website-cloner-template/issues) for something to pick up. For substantial or potentially breaking changes, consider opening an issue first so we can align on the approach before significant work begins.
 
 ## Development setup
 
@@ -20,7 +20,7 @@ Browse the [open issues](https://github.com/JCodesMore/ai-website-cloner-templat
 ```bash
 git clone https://github.com/YOUR-USERNAME/ai-website-cloner-template.git
 cd ai-website-cloner-template
-npm install
+npm ci
 ```
 
 Before opening a PR, make sure the project is green:
@@ -31,22 +31,22 @@ npm run check   # lint + typecheck + build
 
 ## Source-of-truth files & the sync scripts
 
-This is the most important thing to know. Two files power *all* platform support, and their platform-specific copies are **generated** — never edit a generated file directly.
+This is the most important thing to know. Two source files generate the platform-specific project instructions and `/clone-website` skill copies. Edit the source files rather than their generated copies.
 
 | What                   | Edit this (source of truth)             | Then run                           |
 | ---------------------- | --------------------------------------- | ---------------------------------- |
 | Project instructions   | `AGENTS.md`                             | `bash scripts/sync-agent-rules.sh` |
 | `/clone-website` skill | `.claude/skills/clone-website/SKILL.md` | `node scripts/sync-skills.mjs`     |
 
-After editing a source file, run the matching sync command and commit the regenerated files along with your change. CI verifies that the generated files are in sync — if you forget to regenerate, the build will fail with a reminder.
+After editing a source file, run the matching sync command and commit the regenerated files along with your change. CI verifies that the generated files are in sync — if you forget to regenerate, CI will fail with a reminder.
 
 ## Submitting a pull request
 
 1. **Fork** the repo and create a branch off `master` (e.g. `fix/skill-hover-extraction` or `docs/clarify-setup`).
 2. Make your change. If you touched a source-of-truth file, **run the relevant sync script** (see above).
 3. Run `npm run check` and make sure it passes.
-4. Write a clear commit message. This repo uses [Conventional Commits](https://www.conventionalcommits.org/) — e.g. `fix:`, `feat:`, `docs:`, `chore:`, `ci:`.
-5. Open a PR against `master`, fill out the PR template, and link the issue it addresses (`Closes #123`).
+4. Write a clear commit message that describes the change. Prefixes such as `fix:`, `feat:`, or `docs:` are welcome but not required.
+5. Open a PR against `master`, fill out the PR template, and link a relevant issue when one exists (for example, `Closes #123`).
 6. Keep PRs focused — one logical change per PR is much easier to review and merge.
 
 ## Questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thanks for your interest in improving the **AI Website Cloner Template**! This guide covers how to contribute to the template itself.
+
+> **Note:** This repository is a *template*. If you just want to clone a website, don't open a PR here — click **Use this template** to make your own copy and work there (see the [README](README.md#quick-start)). Pull requests should improve the template: the `/clone-website` skill, agent platform support, the scaffold, or the docs.
+
+## Ways to contribute
+
+- **Improve the `/clone-website` skill** — sharper extraction, better prompts, new behaviors to detect
+- **Add or fix agent platform support** — new coding agents, or fixes to existing generated configs
+- **Fix bugs** in the Next.js scaffold or the sync scripts
+- **Improve documentation** — the README, `AGENTS.md`, or the inspection guides under `docs/research/`
+
+Browse the [open issues](https://github.com/JCodesMore/ai-website-cloner-template/issues) for something to pick up. For larger changes, open an issue first so we can align on the approach before you build.
+
+## Development setup
+
+**Prerequisites:** [Node.js](https://nodejs.org/) 24+.
+
+```bash
+git clone https://github.com/YOUR-USERNAME/ai-website-cloner-template.git
+cd ai-website-cloner-template
+npm install
+```
+
+Before opening a PR, make sure the project is green:
+
+```bash
+npm run check   # lint + typecheck + build
+```
+
+## Source-of-truth files & the sync scripts
+
+This is the most important thing to know. Two files power *all* platform support, and their platform-specific copies are **generated** — never edit a generated file directly.
+
+| What                   | Edit this (source of truth)             | Then run                           |
+| ---------------------- | --------------------------------------- | ---------------------------------- |
+| Project instructions   | `AGENTS.md`                             | `bash scripts/sync-agent-rules.sh` |
+| `/clone-website` skill | `.claude/skills/clone-website/SKILL.md` | `node scripts/sync-skills.mjs`     |
+
+After editing a source file, run the matching sync command and commit the regenerated files along with your change. CI verifies that the generated files are in sync — if you forget to regenerate, the build will fail with a reminder.
+
+## Submitting a pull request
+
+1. **Fork** the repo and create a branch off `master` (e.g. `fix/skill-hover-extraction` or `docs/clarify-setup`).
+2. Make your change. If you touched a source-of-truth file, **run the relevant sync script** (see above).
+3. Run `npm run check` and make sure it passes.
+4. Write a clear commit message. This repo uses [Conventional Commits](https://www.conventionalcommits.org/) — e.g. `fix:`, `feat:`, `docs:`, `chore:`, `ci:`.
+5. Open a PR against `master`, fill out the PR template, and link the issue it addresses (`Closes #123`).
+6. Keep PRs focused — one logical change per PR is much easier to review and merge.
+
+## Questions
+
+Ask in the [Discord community](https://discord.gg/hrTSX5yTpB) — happy to help you get started.


### PR DESCRIPTION
## What changed

- Preserves YAMRAJ13y's original contributor guide commit from #58.
- Explains that generated website projects do not belong in this template repository.
- Documents the current Node 24 setup, quality check, source-of-truth files, synchronization commands, and pull-request workflow.
- Refines wording so the guide does not accidentally impose mandatory Conventional Commits or an issue-first policy that the repository has not adopted.
- Describes generated platform rules and skills precisely and matches the synchronization check merged in #90.

## Why

Outside contributors need a short, discoverable explanation of what belongs in this repository and how to update generated agent files safely. GitHub surfaces `CONTRIBUTING.md` when contributors open issues and pull requests.

## Validation

- `npm run check` passed: ESLint, TypeScript, and the Next.js production build.
- Commands, links, source-of-truth mappings, issue and PR guidance, and CI behavior were checked against the current repository.
- Independent read-only review found no accuracy, policy, or suspicious-content issues.

Supersedes #58 while preserving the contributor-authored commit and credit.
