### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-10
+
 ### Added
+- Docker workflows for local development and multi-stage production builds
 - Kiro support through a generated workspace `/clone-website` skill
+- Complete generated workspace skills for Cline and Roo Code, including a Roo slash-command bridge
+- Simplified Chinese and Japanese READMEs with the same onboarding and workflow guidance as the English documentation
+- Contributor and security policies, including a private vulnerability-reporting path
+- CI enforcement that generated agent rules and skills remain synchronized with their source files
+- Compact pipeline diagrams and a static Star History chart in every README
 
 ### Changed
 - Raised the project Node.js baseline to 24 across local development, CI, Docker, and contributor-facing documentation
+- Refreshed Next.js to 16.3, React to 19.2.4, and related dependencies
+- Updated `/clone-website` so later runs preserve existing pages and isolate routes, research, components, assets, and downloaders for each target
+- Improved multi-origin and query/fragment planning with collision-resistant output namespaces and explicit route verification
+- Redesigned README onboarding around the template workflow, Opus 5 recommendation, supported platforms, and community links
+- Hardened the rule and skill generators for current platform schemas and deterministic output
+
+### Fixed
+- Gemini CLI command validation by adding the required name and flattening the prompt schema
+- Cline and Roo Code invocation, frontmatter, and argument handling
+- Next.js documentation resolution in generated agent rules
+- Vulnerable framework dependencies and generated-file consistency checks
+
+### Removed
+- Aider from the officially supported-platform list because its current capabilities cannot run the complete browser and subagent workflow reliably; `.aider.conf.yml` remains available for loading general project context
+
+### Security
+- Documented responsible vulnerability disclosure through GitHub private vulnerability reporting
+- Updated vulnerable dependencies to patched releases
 
 ## [0.3.1] - 2026-03-29
 
@@ -75,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MIT license
 - README with badges, demo section, quick start, and star history
 
-[Unreleased]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/JCodesMore/ai-website-cloner-template/compare/v0.1.1...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-website-clone-template",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-website-clone-template",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-website-clone-template",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "Clone any website into a clean, modern Next.js codebase using AI coding agents",
   "author": "JCodesMore",


### PR DESCRIPTION
## Summary

- publish the complete changelog for the 27 commits since v0.3.1
- bump `package.json` and `package-lock.json` to 0.4.0
- prepare the repository for an annotated `v0.4.0` tag and stable GitHub Release

## Release plan

- **Version:** v0.4.0
- **Proposed title:** v0.4.0 - Expanded Agent Support & Reliable Multi-Page Cloning
- **Tag message:** Expanded agent support, persistent page cloning, and project hardening

This PR does **not** create or publish the tag or GitHub Release. Those remain behind a separate maintainer approval after this PR is reviewed and merged.

## Validation

- `bash scripts/sync-agent-rules.sh`
- `node scripts/sync-skills.mjs`
- `npm run check`
- `git diff --cached --check`
- package and lockfile version parity verified at `0.4.0`