### PR TITLE
fix: fail agent rule sync on missing imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "bash tests/sync-agent-rules.test.sh",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "check": "npm run lint && npm run typecheck && npm run build"
+    "check": "npm run test && npm run lint && npm run typecheck && npm run build"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/sync-agent-rules.sh
+++ b/scripts/sync-agent-rules.sh
@@ -42,7 +42,8 @@ resolve_imports() {
         cat "$resolved"
         echo ""
       else
-        echo "<!-- Import not found: $import_path -->"
+        echo "Error: AGENTS.md import not found: $import_path" >&2
+        return 1
       fi
     else
       echo "$line"

--- a/tests/sync-agent-rules.test.sh
+++ b/tests/sync-agent-rules.test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+mkdir -p "$FIXTURE_ROOT/scripts"
+cp "$REPO_ROOT/scripts/sync-agent-rules.sh" "$FIXTURE_ROOT/scripts/"
+printf '# Fixture instructions\n\n@docs/missing-guide.md\n' > "$FIXTURE_ROOT/AGENTS.md"
+
+set +e
+OUTPUT="$(bash "$FIXTURE_ROOT/scripts/sync-agent-rules.sh" 2>&1)"
+STATUS=$?
+set -e
+
+if [[ $STATUS -eq 0 ]]; then
+  echo "Expected sync-agent-rules.sh to reject a missing @file import" >&2
+  exit 1
+fi
+
+if [[ "$OUTPUT" != *"docs/missing-guide.md"* ]]; then
+  echo "Expected the failure to name the missing import" >&2
+  exit 1
+fi
+
+echo "Missing @file imports fail closed"


### PR DESCRIPTION
## Summary

- Fail `scripts/sync-agent-rules.sh` when an `AGENTS.md` `@file` import does not exist, instead of silently generating incomplete agent instructions.
- Add an isolated regression fixture that requires the command to exit nonzero and name the missing path.

The root cause was that `resolve_imports` emitted an HTML comment for a missing import and continued, so both the command substitution and the overall sync command returned success. That also allowed the generated-file CI check to accept the incomplete output as synchronized.

## Related Issue

No existing issue; exact issue/PR searches found no implementation of this missing-import failure case.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Breaking change

## Regression Evidence

- Before: `bash tests/sync-agent-rules.test.sh` exited `1` because the unmodified script incorrectly returned success.
- After: `bash tests/sync-agent-rules.test.sh` exited `0` and confirmed missing imports fail closed.

## Verification

- `bash tests/sync-agent-rules.test.sh`
- `bash scripts/sync-agent-rules.sh`
- `bash -n scripts/sync-agent-rules.sh tests/sync-agent-rules.test.sh`
- `npm run check`

## Checklist

- [x] `npm run check` passes (lint + typecheck + build)
